### PR TITLE
nimble_parsec 0.5 compatibility

### DIFF
--- a/lib/wormwood/lexer.ex
+++ b/lib/wormwood/lexer.ex
@@ -92,12 +92,12 @@ defmodule Wormwood.Lexer do
       ]),
       times(ascii_char([?.]), 3)
     ])
-    |> traverse({:atom_token, []})
+    |> post_traverse({:atom_token, []})
 
   boolean_value_or_name_or_reserved_word =
     ascii_char([?_, ?A..?Z, ?a..?z])
     |> repeat(ascii_char([?_, ?0..?9, ?A..?Z, ?a..?z]))
-    |> traverse({:boolean_value_or_name_or_reserved_word, []})
+    |> post_traverse({:boolean_value_or_name_or_reserved_word, []})
 
   # NegativeSign :: -
   negative_sign = ascii_char([?-])
@@ -122,7 +122,7 @@ defmodule Wormwood.Lexer do
   int_value =
     empty()
     |> concat(integer_part)
-    |> traverse({:labeled_token, [:int_value]})
+    |> post_traverse({:labeled_token, [:int_value]})
 
   # FractionalPart :: . Digit+
   fractional_part =
@@ -148,15 +148,15 @@ defmodule Wormwood.Lexer do
   float_value =
     choice([
       integer_part |> concat(fractional_part) |> concat(exponent_part),
-      integer_part |> traverse({:fill_mantissa, []}) |> concat(exponent_part),
+      integer_part |> post_traverse({:fill_mantissa, []}) |> concat(exponent_part),
       integer_part |> concat(fractional_part)
     ])
-    |> traverse({:labeled_token, [:float_value]})
+    |> post_traverse({:labeled_token, [:float_value]})
 
   # EscapedUnicode :: /[0-9A-Fa-f]{4}/
   escaped_unicode =
     times(ascii_char([?0..?9, ?A..?F, ?a..?f]), 4)
-    |> traverse({:unescape_unicode, []})
+    |> post_traverse({:unescape_unicode, []})
 
   # EscapedCharacter :: one of `"` \ `/` b f n r t
   escaped_character =
@@ -199,19 +199,17 @@ defmodule Wormwood.Lexer do
   #   - `"""` BlockStringCharacter* `"""`
   string_value =
     ignore(ascii_char([?"]))
-    |> traverse({:mark_string_start, []})
+    |> post_traverse({:mark_string_start, []})
     |> repeat_while(string_character, {:not_end_of_quote, []})
     |> ignore(ascii_char([?"]))
-    |> traverse({:string_value_token, []})
+    |> post_traverse({:string_value_token, []})
 
   block_string_value =
-    ignore(
-      string(~S("""))
-      |> traverse({:mark_block_string_start, []})
-    )
+    ignore(string(~S(""")))
+    |> post_traverse({:mark_block_string_start, []})
     |> repeat_while(block_string_character, {:not_end_of_block_quote, []})
     |> ignore(string(~S(""")))
-    |> traverse({:block_string_value_token, []})
+    |> post_traverse({:block_string_value_token, []})
 
   defp not_end_of_quote(<<?", _::binary>>, context, _, _) do
     {:halt, context}

--- a/mix.exs
+++ b/mix.exs
@@ -21,7 +21,7 @@ defmodule Wormwood.MixProject do
   # Run "mix help deps" to learn about dependencies.
   defp deps() do
     [
-      {:nimble_parsec, "~> 0.4.0"},
+      {:nimble_parsec, "~> 0.5.0"},
       {:ojson, "~> 1.0"}
     ]
   end

--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,4 @@
 %{
-  "nimble_parsec": {:hex, :nimble_parsec, "0.4.0", "ee261bb53214943679422be70f1658fff573c5d0b0a1ecd0f18738944f818efe", [:mix], [], "hexpm"},
+  "nimble_parsec": {:hex, :nimble_parsec, "0.5.0", "90e2eca3d0266e5c53f8fbe0079694740b9c91b6747f2b7e3c5d21966bba8300", [:mix], [], "hexpm"},
   "ojson": {:hex, :ojson, "1.0.0", "fd28614eadaec00a15cdb2f53f29d8717a812a508ddb80d202f2f2e2aaeabbcc", [:mix, :rebar3], [], "hexpm"},
 }


### PR DESCRIPTION
Latest absinthe master relies on nimble_parsec 0.5, but wormwood relies on 0.4. This causes compilation issues. I pulled in some changes from https://github.com/absinthe-graphql/absinthe/pull/709 to get it working with nimble_parsec 0.5.